### PR TITLE
Add ability for clients to override changeset keys

### DIFF
--- a/lib/emque/producing/message/message_with_changeset.rb
+++ b/lib/emque/producing/message/message_with_changeset.rb
@@ -1,7 +1,15 @@
 module Emque
   module Producing
     module MessageWithChangeset
+      module ClassMethods
+        def translate_changeset_attrs(attrs = {})
+          @attrs_to_translate ||= {}
+          @attrs_to_translate.merge!(attrs)
+        end
+      end
+
       def self.included(base)
+        base.extend(ClassMethods)
         base.send(:include, Emque::Producing::Message)
         base.send(:attribute, :partition_key, String, :default => nil, :required => false)
         base.send(:attribute, :change_set, Hash, :default => :build_change_set, :required => true)
@@ -9,10 +17,18 @@ module Emque
         base.send(:private_attribute, :original)
       end
 
+      def translated_attrs
+        self.class.instance_variable_get(:@attrs_to_translate)
+      end
+
       def build_change_set
-        ChangesPayloadGenerator
-          .new({:original => original, :updated => updated})
-          .execute
+        ChangesPayloadGenerator.new(
+          {
+            :original => original,
+            :updated => updated,
+            :translated_attrs => translated_attrs
+          }
+        ).execute
       end
 
       def build_id
@@ -27,18 +43,45 @@ module Emque
     end
 
     class ChangesPayloadGenerator
-      def initialize(opts = {})
-        @original = opts.fetch(:original, {}) || {}
-        @updated = opts.fetch(:updated, {}) || {}
+      def initialize(changeset_data = {})
+        @original = changeset_data[:original] || {}
+        @updated = changeset_data[:updated] || {}
+        @translated_attrs = changeset_data[:translated_attrs] || {}
       end
 
       def execute
+        translate_attrs if translated_attrs.any?
         {:original => original, :updated => updated, :delta => delta}
       end
 
       private
 
-      attr_reader :original, :updated
+      attr_reader :original, :updated, :translated_attrs
+
+      def translate_attrs
+        @original = translate(original)
+        @updated = translate(updated)
+      end
+
+      def deep_copy(attr_set)
+        Oj.load(Oj.dump(attr_set))
+      end
+
+      def translate(attr_set)
+        deep_copy(attr_set).tap do |cloned_attrs|
+          stringified_attrs.each_pair do |old_name, new_name|
+            if cloned_attrs.key?(old_name)
+              cloned_attrs[new_name] = cloned_attrs.delete(old_name)
+            end
+          end
+        end
+      end
+
+      def stringified_attrs
+        {}.tap do |new_hash|
+          translated_attrs.each_pair { |k,v| new_hash[k.to_s] = v.to_s }
+        end
+      end
 
       def delta
         if original.empty?


### PR DESCRIPTION
This commit is being submitted to enable clients to address issues of needing
to normalize message contents across disparate message producers.
Specifically, when Producer A has a slightly different naming convention than
that of Producer B, this commit allows either Producer A or Producer B to
alias a given set of attributes in the object changeset to be consistent.