### PR TITLE
Fixes #25 to allow non-confirmed messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or install it yourself as:
     Emque::Producing.configure do |c|
       c.app_name = "app"
       c.publishing_adapter = :rabbitmq
-      c.rabbitmq_options = { :url => "amqp://guest:guest@localhost:5672" }
+      c.rabbitmq_options[:url] = "amqp://guest:guest@localhost:5672"
       c.error_handlers << Proc.new {|ex,context|
        # notify/log
       }

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oj",        "~> 2.11"
-  spec.add_dependency "virtus",    "~> 1.0"
+  spec.add_dependency "oj",        "~> 2.11.4"
+  spec.add_dependency "virtus",    "~> 1.0.4"
 
   spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake",    "~> 10.4"
-  spec.add_development_dependency "rspec", "~> 3.2"
+  spec.add_development_dependency "rake",    "~> 10.4.2"
+  spec.add_development_dependency "rspec",   "~> 3.2.0"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "bunny", "~> 1.7"
+  spec.add_development_dependency "bunny", "~> 1.7.0"
 end

--- a/lib/emque/producing/configuration.rb
+++ b/lib/emque/producing/configuration.rb
@@ -14,7 +14,10 @@ module Emque
         @error_handlers = []
         @log_publish_message = false
         @publish_messages = true
-        @rabbitmq_options = { :url => "amqp://guest:guest@localhost:5672" }
+        @rabbitmq_options = {
+          :url => "amqp://guest:guest@localhost:5672",
+          :requires_confirmation => true
+        }
       end
     end
   end

--- a/lib/emque/producing/configuration.rb
+++ b/lib/emque/producing/configuration.rb
@@ -3,10 +3,10 @@ module Emque
     class Configuration
       attr_accessor :app_name
       attr_accessor :publishing_adapter
-      attr_accessor :rabbitmq_options
       attr_accessor :error_handlers
       attr_accessor :log_publish_message
       attr_accessor :publish_messages
+      attr_reader :rabbitmq_options
 
       def initialize
         @app_name = ""

--- a/lib/emque/producing/configuration.rb
+++ b/lib/emque/producing/configuration.rb
@@ -15,9 +15,7 @@ module Emque
         @log_publish_message = false
         @publish_messages = true
         @rabbitmq_options = {
-          :url => "amqp://guest:guest@localhost:5672",
-          :confirm_messages => true,
-          :mandatory_messages => true
+          :url => "amqp://guest:guest@localhost:5672"
         }
       end
     end

--- a/lib/emque/producing/configuration.rb
+++ b/lib/emque/producing/configuration.rb
@@ -16,7 +16,8 @@ module Emque
         @publish_messages = true
         @rabbitmq_options = {
           :url => "amqp://guest:guest@localhost:5672",
-          :requires_confirmation => true
+          :confirm_messages => true,
+          :mandatory_messages => true
         }
       end
     end

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -24,6 +24,22 @@ module Emque
           @message_type
         end
 
+        def mandatory(name)
+          @mandatory = name
+        end
+
+        def read_mandatory
+          @mandatory || true
+        end
+
+        def requires_confirmation(name)
+          @requires_confirmation = name
+        end
+
+        def read_requires_confirmation
+          @requires_confirmation || true
+        end
+
         def private_attribute(name, coercion=nil, opts={})
           @private_attrs ||= []
           @private_attrs << name
@@ -64,6 +80,14 @@ module Emque
         self.class.read_message_type
       end
 
+      def mandatory
+        self.class.read_mandatory
+      end
+
+      def requires_confirmation
+        self.class.read_requires_confirmation
+      end
+
       def valid?
         invalid_attributes.empty? && topic && message_type
       end
@@ -86,7 +110,9 @@ module Emque
         if valid?
           log "valid...", true
           if Emque::Producing.configuration.publish_messages
-            sent = publisher.publish(topic, message_type, to_json, partition_key)
+            sent = publisher.publish(
+              topic, message_type, to_json, mandatory, requires_confirmation, partition_key
+            )
             log "sent #{sent}"
             raise MessagesNotSentError.new unless sent
           end

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -24,20 +24,16 @@ module Emque
           @message_type
         end
 
-        def mandatory(name)
-          @mandatory = name
+        def raise_message_failure(name)
+          @raise_message_failure = name
         end
 
-        def read_mandatory
-          @mandatory || true
-        end
-
-        def requires_confirmation(name)
-          @requires_confirmation = name
-        end
-
-        def read_requires_confirmation
-          @requires_confirmation || true
+        def read_raise_message_failure
+          if @raise_message_failure.nil?
+            true
+          else
+            @raise_message_failure
+          end
         end
 
         def private_attribute(name, coercion=nil, opts={})
@@ -80,12 +76,8 @@ module Emque
         self.class.read_message_type
       end
 
-      def mandatory
-        self.class.read_mandatory
-      end
-
-      def requires_confirmation
-        self.class.read_requires_confirmation
+      def raise_message_failure
+        self.class.read_raise_message_failure
       end
 
       def valid?
@@ -111,7 +103,7 @@ module Emque
           log "valid...", true
           if Emque::Producing.configuration.publish_messages
             sent = publisher.publish(
-              topic, message_type, to_json, mandatory, requires_confirmation, partition_key
+              topic, message_type, to_json, raise_message_failure, partition_key
             )
             log "sent #{sent}"
             raise MessagesNotSentError.new unless sent

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -24,15 +24,15 @@ module Emque
           @message_type
         end
 
-        def raise_message_failure(name)
-          @raise_message_failure = name
+        def raise_on_failure(name)
+          @raise_on_failure = name
         end
 
-        def read_raise_message_failure
-          if @raise_message_failure.nil?
+        def read_raise_on_failure
+          if @raise_on_failure.nil?
             true
           else
-            @raise_message_failure
+            @raise_on_failure
           end
         end
 
@@ -76,8 +76,8 @@ module Emque
         self.class.read_message_type
       end
 
-      def raise_message_failure
-        self.class.read_raise_message_failure
+      def raise_on_failure?
+        self.class.read_raise_on_failure
       end
 
       def valid?
@@ -104,7 +104,7 @@ module Emque
           if Emque::Producing.configuration.publish_messages
             sent = publisher.publish(topic, message_type, to_json, partition_key)
             log "sent #{sent}"
-            if raise_message_failure && !sent
+            if raise_on_failure? && !sent
               raise MessagesNotSentError.new
             end
           end

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -102,11 +102,11 @@ module Emque
         if valid?
           log "valid...", true
           if Emque::Producing.configuration.publish_messages
-            sent = publisher.publish(
-              topic, message_type, to_json, raise_message_failure, partition_key
-            )
+            sent = publisher.publish(topic, message_type, to_json, partition_key)
             log "sent #{sent}"
-            raise MessagesNotSentError.new unless sent
+            if raise_message_failure && !sent
+              raise MessagesNotSentError.new
+            end
           end
         else
           log "failed...", true

--- a/lib/emque/producing/publisher/rabbitmq.rb
+++ b/lib/emque/producing/publisher/rabbitmq.rb
@@ -17,14 +17,12 @@ module Emque
             20.times { |i| queue << CONN.create_channel }
           }
 
-        def publish(topic, message_type, message, key = nil)
+        def publish(topic, message_type, message, requires_confirmation, is_mandatory, key = nil)
           ch = CHANNEL_POOL.pop
           ch.open if ch.closed?
           begin
             exchange = ch.fanout(topic, :durable => true, :auto_delete => false)
             sent = true
-            requires_confirmation = Emque::Producing.configuration.rabbitmq_options[:confirm_messages]
-            is_mandatory = Emque::Producing.configuration.rabbitmq_options[:mandatory_messages]
 
             if requires_confirmation
               ch.confirm_select unless ch.using_publisher_confirmations?

--- a/lib/emque/producing/publisher/rabbitmq.rb
+++ b/lib/emque/producing/publisher/rabbitmq.rb
@@ -17,18 +17,15 @@ module Emque
             20.times { |i| queue << CONN.create_channel }
           }
 
-        def publish(topic, message_type, message, requires_confirmation, is_mandatory, key = nil)
+        def publish(topic, message_type, message, raise_message_failure, key = nil)
           ch = CHANNEL_POOL.pop
           ch.open if ch.closed?
           begin
             exchange = ch.fanout(topic, :durable => true, :auto_delete => false)
             sent = true
 
-            if requires_confirmation
+            if raise_message_failure
               ch.confirm_select unless ch.using_publisher_confirmations?
-            end
-
-            if is_mandatory
               exchange.on_return do |return_info, properties, content|
                 Emque::Producing.logger.warn("App [#{properties[:app_id]}] message was returned from exchange [#{return_info[:exchange]}]")
                 sent = false
@@ -37,13 +34,13 @@ module Emque
 
             exchange.publish(
               message,
-              :mandatory => is_mandatory,
+              :mandatory => raise_message_failure,
               :persistent => true,
               :type => message_type,
               :app_id => Emque::Producing.configuration.app_name,
               :content_type => "application/json")
 
-            if requires_confirmation
+            if raise_message_failure
               success = ch.wait_for_confirms
               unless success
                 Emque::Producing.logger.warn("RabbitMQ Publisher: message was nacked")

--- a/lib/emque/producing/version.rb
+++ b/lib/emque/producing/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Producing
-    VERSION = "1.0.0.beta2"
+    VERSION = "1.0.0.beta3"
   end
 end

--- a/spec/producing/configuration_spec.rb
+++ b/spec/producing/configuration_spec.rb
@@ -18,12 +18,4 @@ describe Emque::Producing::Configuration do
       subject.rabbitmq_options = {:requires_confirmation => false}
     }.to raise_error
   end
-
-  it "rabbitmq mandatory_messages default is true" do
-    expect(subject.rabbitmq_options[:mandatory_messages]).to eq true
-  end
-
-  it "rabbitmq confirm_messages default is true" do
-    expect(subject.rabbitmq_options[:confirm_messages]).to eq true
-  end
 end

--- a/spec/producing/configuration_spec.rb
+++ b/spec/producing/configuration_spec.rb
@@ -12,4 +12,9 @@ describe Emque::Producing::Configuration do
     subject.app_name = "my app"
     expect(subject.app_name).to eq "my app"
   end
+
+  it "allows app_name to be overwritten" do
+    subject.rabbitmq_options[:requires_confirmation] = false
+    expect(subject.rabbitmq_options[:requires_confirmation]).to eq false
+  end
 end

--- a/spec/producing/configuration_spec.rb
+++ b/spec/producing/configuration_spec.rb
@@ -13,8 +13,13 @@ describe Emque::Producing::Configuration do
     expect(subject.app_name).to eq "my app"
   end
 
-  it "allows app_name to be overwritten" do
-    subject.rabbitmq_options[:requires_confirmation] = false
-    expect(subject.rabbitmq_options[:requires_confirmation]).to eq false
+  it "does not allow rabbitmq_options to be overwritten" do
+    expect {
+      subject.rabbitmq_options = {:requires_confirmation => false}
+    }.to raise_error
+  end
+
+  it "rabbitmq requires_confirmation default is true" do
+    expect(subject.rabbitmq_options[:requires_confirmation]).to eq true
   end
 end

--- a/spec/producing/configuration_spec.rb
+++ b/spec/producing/configuration_spec.rb
@@ -19,7 +19,11 @@ describe Emque::Producing::Configuration do
     }.to raise_error
   end
 
-  it "rabbitmq requires_confirmation default is true" do
-    expect(subject.rabbitmq_options[:requires_confirmation]).to eq true
+  it "rabbitmq mandatory_messages default is true" do
+    expect(subject.rabbitmq_options[:mandatory_messages]).to eq true
+  end
+
+  it "rabbitmq confirm_messages default is true" do
+    expect(subject.rabbitmq_options[:confirm_messages]).to eq true
   end
 end


### PR DESCRIPTION
In order to support use cases that need higher-throughput, and no exceptions for less critical messages, allow message confirmation to be optional.  This means messages could be dropped, but also means the application producing the message will  not fail because of a dropped message, which could be a valid use case.