### PR TITLE
Lower Oj and virtus to be compatible with older emque-consuming services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oj",        "~> 2.11.4"
-  spec.add_dependency "virtus",    "~> 1.0.4"
+  spec.add_dependency "oj",        "~> 2.10"
+  spec.add_dependency "virtus",    "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake",    "~> 10.4.2"

--- a/lib/emque/producing/version.rb
+++ b/lib/emque/producing/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Producing
-    VERSION = "1.0.0.beta3"
+    VERSION = "1.0.0.beta4"
   end
 end


### PR DESCRIPTION
Hit a version conflict with an older emque-consuming service, that I'm trying to instrument with emque-stats, that is locked into earlier versions of Oj and virtus. This update relaxes those version constraints.